### PR TITLE
Add structured error types for better error handling

### DIFF
--- a/lib/puck/error.ex
+++ b/lib/puck/error.ex
@@ -1,0 +1,230 @@
+defmodule Puck.Error do
+  @moduledoc """
+  Structured error types for Puck operations.
+
+  Puck uses tagged tuples for errors, following Elixir conventions. This module
+  defines the error structure and provides helper functions for introspection.
+
+  ## Error Structure
+
+  All errors follow the pattern `{:error, reason}` where `reason` is a tagged tuple:
+
+      {:error, {:hook, stage, original_reason}}
+      {:error, {:backend, backend_module, original_reason}}
+      {:error, {:validation, message}}
+
+  ## Examples
+
+      case Puck.call(client, "Hello") do
+        {:ok, response, context} ->
+          response.content
+
+        {:error, {:hook, :on_call_start, :blocked}} ->
+          "Blocked by guardrails"
+
+        {:error, {:backend, Puck.Backends.ReqLLM, :timeout}} ->
+          "Request timed out"
+
+        {:error, reason} ->
+          "Unknown error: \#{inspect(reason)}"
+      end
+
+  ## Helper Functions
+
+      error = {:backend, Puck.Backends.ReqLLM, :rate_limited}
+
+      Puck.Error.stage(error)   # => :backend
+      Puck.Error.reason(error)  # => :rate_limited
+      Puck.Error.message(error) # => "Backend Puck.Backends.ReqLLM error: rate_limited"
+
+  """
+
+  @typedoc """
+  The stage where an error occurred.
+
+  - `:hook` - Error from a hook callback
+  - `:backend` - Error from the LLM backend
+  - `:validation` - Input validation error
+  - `:stream` - Error during streaming
+  """
+  @type stage :: :hook | :backend | :validation | :stream
+
+  @typedoc """
+  Hook callback names that can produce errors.
+  """
+  @type hook_callback ::
+          :on_call_start
+          | :on_call_end
+          | :on_stream_start
+          | :on_backend_request
+          | :on_backend_response
+
+  @typedoc """
+  Structured error reasons.
+
+  - `{:hook, callback, reason}` - Hook returned an error
+  - `{:backend, module, reason}` - Backend call failed
+  - `{:validation, message}` - Input validation failed
+  - `{:stream, reason}` - Streaming error
+  - `term()` - Unstructured legacy error (pass-through)
+  """
+  @type reason ::
+          {:hook, hook_callback(), term()}
+          | {:backend, module(), term()}
+          | {:validation, String.t()}
+          | {:stream, term()}
+          | term()
+
+  @doc """
+  Returns the stage where the error occurred.
+
+  ## Examples
+
+      iex> Puck.Error.stage({:hook, :on_call_start, :blocked})
+      :hook
+
+      iex> Puck.Error.stage({:backend, Puck.Backends.ReqLLM, :timeout})
+      :backend
+
+      iex> Puck.Error.stage(:some_legacy_error)
+      :unknown
+
+  """
+  @spec stage(reason()) :: stage() | :unknown
+  def stage({:hook, _callback, _reason}), do: :hook
+  def stage({:backend, _module, _reason}), do: :backend
+  def stage({:validation, _message}), do: :validation
+  def stage({:stream, _reason}), do: :stream
+  def stage(_), do: :unknown
+
+  @doc """
+  Extracts the underlying reason from a structured error.
+
+  ## Examples
+
+      iex> Puck.Error.reason({:hook, :on_call_start, :blocked})
+      :blocked
+
+      iex> Puck.Error.reason({:backend, Puck.Backends.ReqLLM, {:timeout, 5000}})
+      {:timeout, 5000}
+
+      iex> Puck.Error.reason(:legacy_error)
+      :legacy_error
+
+  """
+  @spec reason(reason()) :: term()
+  def reason({:hook, _callback, reason}), do: reason
+  def reason({:backend, _module, reason}), do: reason
+  def reason({:validation, message}), do: message
+  def reason({:stream, reason}), do: reason
+  def reason(reason), do: reason
+
+  @doc """
+  Returns the hook callback name for hook errors.
+
+  ## Examples
+
+      iex> Puck.Error.callback({:hook, :on_call_start, :blocked})
+      :on_call_start
+
+      iex> Puck.Error.callback({:backend, Puck.Backends.ReqLLM, :timeout})
+      nil
+
+  """
+  @spec callback(reason()) :: hook_callback() | nil
+  def callback({:hook, callback, _reason}), do: callback
+  def callback(_), do: nil
+
+  @doc """
+  Returns the backend module for backend errors.
+
+  ## Examples
+
+      iex> Puck.Error.backend({:backend, Puck.Backends.ReqLLM, :timeout})
+      Puck.Backends.ReqLLM
+
+      iex> Puck.Error.backend({:hook, :on_call_start, :blocked})
+      nil
+
+  """
+  @spec backend(reason()) :: module() | nil
+  def backend({:backend, module, _reason}), do: module
+  def backend(_), do: nil
+
+  @doc """
+  Returns a human-readable error message.
+
+  ## Examples
+
+      iex> Puck.Error.message({:hook, :on_call_start, :blocked})
+      "Hook on_call_start error: blocked"
+
+      iex> Puck.Error.message({:backend, Puck.Backends.ReqLLM, :timeout})
+      "Backend Elixir.Puck.Backends.ReqLLM error: timeout"
+
+      iex> Puck.Error.message({:validation, "content cannot be empty"})
+      "Validation error: content cannot be empty"
+
+  """
+  @spec message(reason()) :: String.t()
+  def message({:hook, callback, reason}) do
+    "Hook #{callback} error: #{format_reason(reason)}"
+  end
+
+  def message({:backend, module, reason}) do
+    "Backend #{module} error: #{format_reason(reason)}"
+  end
+
+  def message({:validation, msg}) do
+    "Validation error: #{msg}"
+  end
+
+  def message({:stream, reason}) do
+    "Stream error: #{format_reason(reason)}"
+  end
+
+  def message(reason) do
+    "Error: #{format_reason(reason)}"
+  end
+
+  @doc """
+  Checks if an error is structured (has stage information).
+
+  ## Examples
+
+      iex> Puck.Error.structured?({:hook, :on_call_start, :blocked})
+      true
+
+      iex> Puck.Error.structured?(:legacy_error)
+      false
+
+  """
+  @spec structured?(reason()) :: boolean()
+  def structured?({:hook, _, _}), do: true
+  def structured?({:backend, _, _}), do: true
+  def structured?({:validation, _}), do: true
+  def structured?({:stream, _}), do: true
+  def structured?(_), do: false
+
+  @doc """
+  Wraps an error reason with hook context.
+
+  Used internally by `Puck.Runtime` to add context to hook errors.
+  """
+  @spec wrap_hook(hook_callback(), term()) :: {:hook, hook_callback(), term()}
+  def wrap_hook(callback, reason), do: {:hook, callback, reason}
+
+  @doc """
+  Wraps an error reason with backend context.
+
+  Used internally by `Puck.Runtime` to add context to backend errors.
+  """
+  @spec wrap_backend(module(), term()) :: {:backend, module(), term()}
+  def wrap_backend(module, reason), do: {:backend, module, reason}
+
+  # Private helpers
+
+  defp format_reason(reason) when is_binary(reason), do: reason
+  defp format_reason(reason) when is_atom(reason), do: Atom.to_string(reason)
+  defp format_reason(reason), do: inspect(reason)
+end

--- a/lib/puck/telemetry/hooks.ex
+++ b/lib/puck/telemetry/hooks.ex
@@ -151,7 +151,20 @@ if Code.ensure_loaded?(:telemetry) do
     end
 
     defp normalize_error(reason) do
-      {:error, reason, []}
+      # Build structured error info if available
+      error_info =
+        if Puck.Error.structured?(reason) do
+          %{
+            reason: reason,
+            stage: Puck.Error.stage(reason),
+            underlying_reason: Puck.Error.reason(reason),
+            message: Puck.Error.message(reason)
+          }
+        else
+          reason
+        end
+
+      {:error, error_info, []}
     end
   end
 end

--- a/test/puck/error_test.exs
+++ b/test/puck/error_test.exs
@@ -1,0 +1,133 @@
+defmodule Puck.ErrorTest do
+  use ExUnit.Case, async: true
+
+  alias Puck.Error
+
+  describe "stage/1" do
+    test "returns :hook for hook errors" do
+      assert Error.stage({:hook, :on_call_start, :blocked}) == :hook
+    end
+
+    test "returns :backend for backend errors" do
+      assert Error.stage({:backend, Puck.Backends.ReqLLM, :timeout}) == :backend
+    end
+
+    test "returns :validation for validation errors" do
+      assert Error.stage({:validation, "content cannot be empty"}) == :validation
+    end
+
+    test "returns :stream for stream errors" do
+      assert Error.stage({:stream, :halted_by_hook}) == :stream
+    end
+
+    test "returns :unknown for unstructured errors" do
+      assert Error.stage(:some_error) == :unknown
+      assert Error.stage("string error") == :unknown
+      assert Error.stage({:unexpected, :format}) == :unknown
+    end
+  end
+
+  describe "reason/1" do
+    test "extracts reason from hook errors" do
+      assert Error.reason({:hook, :on_call_start, :blocked}) == :blocked
+    end
+
+    test "extracts reason from backend errors" do
+      assert Error.reason({:backend, Puck.Backends.ReqLLM, {:timeout, 5000}}) == {:timeout, 5000}
+    end
+
+    test "extracts message from validation errors" do
+      assert Error.reason({:validation, "bad input"}) == "bad input"
+    end
+
+    test "extracts reason from stream errors" do
+      assert Error.reason({:stream, :halted_by_hook}) == :halted_by_hook
+    end
+
+    test "returns unstructured errors as-is" do
+      assert Error.reason(:legacy_error) == :legacy_error
+      assert Error.reason("string error") == "string error"
+    end
+  end
+
+  describe "callback/1" do
+    test "returns callback name for hook errors" do
+      assert Error.callback({:hook, :on_call_start, :blocked}) == :on_call_start
+      assert Error.callback({:hook, :on_backend_request, :failed}) == :on_backend_request
+    end
+
+    test "returns nil for non-hook errors" do
+      assert Error.callback({:backend, Puck.Backends.Mock, :error}) == nil
+      assert Error.callback(:legacy_error) == nil
+    end
+  end
+
+  describe "backend/1" do
+    test "returns module for backend errors" do
+      assert Error.backend({:backend, Puck.Backends.ReqLLM, :timeout}) == Puck.Backends.ReqLLM
+      assert Error.backend({:backend, Puck.Backends.Mock, :error}) == Puck.Backends.Mock
+    end
+
+    test "returns nil for non-backend errors" do
+      assert Error.backend({:hook, :on_call_start, :blocked}) == nil
+      assert Error.backend(:legacy_error) == nil
+    end
+  end
+
+  describe "message/1" do
+    test "formats hook errors" do
+      assert Error.message({:hook, :on_call_start, :blocked}) ==
+               "Hook on_call_start error: blocked"
+    end
+
+    test "formats backend errors" do
+      msg = Error.message({:backend, Puck.Backends.ReqLLM, :timeout})
+      assert msg =~ "Backend"
+      assert msg =~ "ReqLLM"
+      assert msg =~ "timeout"
+    end
+
+    test "formats validation errors" do
+      assert Error.message({:validation, "content cannot be empty"}) ==
+               "Validation error: content cannot be empty"
+    end
+
+    test "formats stream errors" do
+      assert Error.message({:stream, :halted_by_hook}) ==
+               "Stream error: halted_by_hook"
+    end
+
+    test "formats unstructured errors" do
+      assert Error.message(:some_error) == "Error: some_error"
+    end
+  end
+
+  describe "structured?/1" do
+    test "returns true for structured errors" do
+      assert Error.structured?({:hook, :on_call_start, :blocked})
+      assert Error.structured?({:backend, Puck.Backends.Mock, :error})
+      assert Error.structured?({:validation, "message"})
+      assert Error.structured?({:stream, :halted})
+    end
+
+    test "returns false for unstructured errors" do
+      refute Error.structured?(:legacy_error)
+      refute Error.structured?("string error")
+      refute Error.structured?({:unexpected, :format})
+    end
+  end
+
+  describe "wrap_hook/2" do
+    test "wraps reason with hook context" do
+      assert Error.wrap_hook(:on_call_start, :blocked) ==
+               {:hook, :on_call_start, :blocked}
+    end
+  end
+
+  describe "wrap_backend/2" do
+    test "wraps reason with backend context" do
+      assert Error.wrap_backend(Puck.Backends.Mock, :timeout) ==
+               {:backend, Puck.Backends.Mock, :timeout}
+    end
+  end
+end

--- a/test/puck_test.exs
+++ b/test/puck_test.exs
@@ -45,7 +45,8 @@ defmodule PuckTest do
       client = Client.new({Puck.Backends.Mock, error: :rate_limited})
       context = Context.new()
 
-      assert {:error, :rate_limited} = Puck.call(client, "Hello!", context)
+      assert {:error, {:backend, Puck.Backends.Mock, :rate_limited}} =
+               Puck.call(client, "Hello!", context)
     end
 
     test "accepts multi-modal content" do
@@ -85,7 +86,8 @@ defmodule PuckTest do
       client = Client.new({Puck.Backends.Mock, error: :connection_failed})
       context = Context.new()
 
-      assert {:error, :connection_failed} = Puck.stream(client, "Hello!", context)
+      assert {:error, {:backend, Puck.Backends.Mock, :connection_failed}} =
+               Puck.stream(client, "Hello!", context)
     end
   end
 


### PR DESCRIPTION
Introduce Puck.Error module with tagged tuple error types that provide
context about where errors occurred (hook, backend, validation, stream).
This enables pattern matching on error stages and extracting underlying
reasons for debugging.

- Add Puck.Error with stage/reason/callback/backend helper functions
- Update Puck.Runtime to wrap hook and backend errors with context
- Update telemetry hooks to extract structured error info
- Update tests to expect structured error tuples