### PR TITLE
Fix stream_event partial chunk matching in ClaudeAgentSDK backend

### DIFF
--- a/lib/puck/backends/claude_agent_sdk.ex
+++ b/lib/puck/backends/claude_agent_sdk.ex
@@ -307,7 +307,17 @@ if Code.ensure_loaded?(ClaudeAgentSDK) do
 
     defp to_chunk(%ClaudeAgentSDK.Message{type: :stream_event, data: data}) do
       case data do
-        %{event: %{type: "content_block_delta", delta: %{text: text}}} when is_binary(text) ->
+        %{event: %{"type" => "content_block_delta", "delta" => %{"text" => text}}}
+        when is_binary(text) ->
+          [
+            %{
+              type: :content,
+              content: text,
+              metadata: %{backend: :claude_agent_sdk, partial: true}
+            }
+          ]
+
+        %{event: %{type: :text_delta, text: text}} when is_binary(text) ->
           [
             %{
               type: :content,

--- a/test/integration/claude_agent_sdk_test.exs
+++ b/test/integration/claude_agent_sdk_test.exs
@@ -126,6 +126,21 @@ defmodule Puck.Integration.ClaudeAgentSDKTest do
     end
 
     @tag timeout: 120_000
+    test "emits partial streaming chunks", %{client: client} do
+      {:ok, stream, _ctx} =
+        Puck.stream(client, "Say hello in a short sentence.", Puck.Context.new())
+
+      chunks = Enum.to_list(stream)
+      partial = Enum.filter(chunks, &(Map.get(&1.metadata, :partial) == true))
+
+      assert partial != [], "expected at least one partial chunk from stream_event handling"
+
+      Enum.each(partial, fn chunk ->
+        assert is_binary(chunk.content)
+      end)
+    end
+
+    @tag timeout: 120_000
     test "can collect final result from stream", %{client: client} do
       {:ok, stream, _ctx} =
         Puck.stream(client, "What is the capital of France? Answer briefly.", Puck.Context.new())

--- a/test/puck/backends/claude_agent_sdk_test.exs
+++ b/test/puck/backends/claude_agent_sdk_test.exs
@@ -184,6 +184,169 @@ if Code.ensure_loaded?(ClaudeAgentSDK) do
       end
     end
 
+    describe "stream/3 partial chunks" do
+      test "emits partial chunks for content_block_delta stream events", %{config: config} do
+        stub(ClaudeAgentSDK, :query, fn _prompt, _opts ->
+          [
+            %ClaudeAgentSDK.Message{
+              type: :stream_event,
+              data: %{
+                event: %{
+                  "type" => "content_block_delta",
+                  "delta" => %{"text" => "hello"}
+                }
+              },
+              raw: %{}
+            },
+            %ClaudeAgentSDK.Message{
+              type: :result,
+              subtype: :success,
+              data: %{
+                session_id: "s1",
+                result: "hello",
+                subtype: :success,
+                usage: %{input_tokens: 1, output_tokens: 1}
+              },
+              raw: %{}
+            }
+          ]
+        end)
+
+        messages = [Message.new(:user, "hi")]
+        {:ok, stream} = Backend.stream(config, messages, [])
+        chunks = Enum.to_list(stream)
+
+        partial = Enum.filter(chunks, &(&1.metadata[:partial] == true))
+        assert length(partial) == 1
+        assert hd(partial).content == "hello"
+      end
+
+      test "emits partial chunks for EventParser-transformed text_delta events", %{config: config} do
+        stub(ClaudeAgentSDK, :query, fn _prompt, _opts ->
+          [
+            %ClaudeAgentSDK.Message{
+              type: :stream_event,
+              data: %{
+                event: %{type: :text_delta, text: "hello", accumulated: "hello"}
+              },
+              raw: %{}
+            },
+            %ClaudeAgentSDK.Message{
+              type: :result,
+              subtype: :success,
+              data: %{
+                session_id: "s1",
+                result: "hello",
+                subtype: :success,
+                usage: %{input_tokens: 1, output_tokens: 1}
+              },
+              raw: %{}
+            }
+          ]
+        end)
+
+        messages = [Message.new(:user, "hi")]
+        {:ok, stream} = Backend.stream(config, messages, [])
+        chunks = Enum.to_list(stream)
+
+        partial = Enum.filter(chunks, &(&1.metadata[:partial] == true))
+        assert length(partial) == 1
+        assert hd(partial).content == "hello"
+      end
+
+      test "ignores non-delta stream events", %{config: config} do
+        stub(ClaudeAgentSDK, :query, fn _prompt, _opts ->
+          [
+            %ClaudeAgentSDK.Message{
+              type: :stream_event,
+              data: %{
+                event: %{
+                  "type" => "content_block_start",
+                  "content_block" => %{"type" => "text", "text" => ""}
+                }
+              },
+              raw: %{}
+            },
+            %ClaudeAgentSDK.Message{
+              type: :result,
+              subtype: :success,
+              data: %{
+                session_id: "s1",
+                result: "done",
+                subtype: :success,
+                usage: %{input_tokens: 1, output_tokens: 1}
+              },
+              raw: %{}
+            }
+          ]
+        end)
+
+        messages = [Message.new(:user, "hi")]
+        {:ok, stream} = Backend.stream(config, messages, [])
+        chunks = Enum.to_list(stream)
+
+        partial = Enum.filter(chunks, &(&1.metadata[:partial] == true))
+        assert partial == []
+      end
+
+      test "collects multiple partial chunks from a stream", %{config: config} do
+        stub(ClaudeAgentSDK, :query, fn _prompt, _opts ->
+          [
+            %ClaudeAgentSDK.Message{
+              type: :stream_event,
+              data: %{
+                event: %{
+                  "type" => "content_block_delta",
+                  "delta" => %{"text" => "one"}
+                }
+              },
+              raw: %{}
+            },
+            %ClaudeAgentSDK.Message{
+              type: :stream_event,
+              data: %{
+                event: %{
+                  "type" => "content_block_delta",
+                  "delta" => %{"text" => " two"}
+                }
+              },
+              raw: %{}
+            },
+            %ClaudeAgentSDK.Message{
+              type: :stream_event,
+              data: %{
+                event: %{
+                  "type" => "content_block_delta",
+                  "delta" => %{"text" => " three"}
+                }
+              },
+              raw: %{}
+            },
+            %ClaudeAgentSDK.Message{
+              type: :result,
+              subtype: :success,
+              data: %{
+                session_id: "s1",
+                result: "one two three",
+                subtype: :success,
+                usage: %{input_tokens: 1, output_tokens: 3}
+              },
+              raw: %{}
+            }
+          ]
+        end)
+
+        messages = [Message.new(:user, "count")]
+        {:ok, stream} = Backend.stream(config, messages, [])
+        chunks = Enum.to_list(stream)
+
+        partial = Enum.filter(chunks, &(&1.metadata[:partial] == true))
+        assert length(partial) == 3
+        texts = Enum.map(partial, & &1.content)
+        assert texts == ["one", " two", " three"]
+      end
+    end
+
     describe "stream/3 session resume" do
       test "starts new session without session_id", %{config: config} do
         expect(ClaudeAgentSDK, :query, fn "hello", _opts ->


### PR DESCRIPTION
## Summary

- Fix `to_chunk/1` for `:stream_event` messages which pattern-matched with atom keys but the SDK delivers string-keyed maps (CLIStream) or EventParser-transformed atom-keyed maps (ClientStream)
- Handle both event formats so partial streaming chunks are emitted regardless of which SDK code path is active
- Add unit tests covering both event formats, non-delta event filtering, and multiple partial chunk collection
- Add integration test verifying partial chunks are emitted during real streaming

## Test plan

- [x] Unit tests pass: `mix test test/puck/backends/claude_agent_sdk_test.exs` (17 tests, 0 failures)
- [x] Full test suite passes: `mix test` (361 tests, 0 failures)
- [x] Integration tests pass: `mix test --only claude_agent_sdk` (11 tests, 0 failures)