### PR TITLE
Forward tools config to ClaudeAgentSDK backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Claude Agent SDK backend now forwards the `:tools` config option, enabling tool-free chatbots via `tools: []`
+
 ## [0.2.10] - 2026-02-05
 
 ### Fixed

--- a/lib/puck/backends/claude_agent_sdk.ex
+++ b/lib/puck/backends/claude_agent_sdk.ex
@@ -151,6 +151,7 @@ if Code.ensure_loaded?(ClaudeAgentSDK) do
     defp build_sdk_options(config, messages, output_schema) do
       opts = %ClaudeAgentSDK.Options{
         cwd: config[:cwd],
+        tools: config[:tools],
         allowed_tools: config[:allowed_tools],
         disallowed_tools: config[:disallowed_tools],
         permission_mode: config[:permission_mode],

--- a/test/puck/backends/claude_agent_sdk_test.exs
+++ b/test/puck/backends/claude_agent_sdk_test.exs
@@ -96,6 +96,30 @@ if Code.ensure_loaded?(ClaudeAgentSDK) do
       {:ok, config: config}
     end
 
+    describe "tools config forwarding" do
+      test "forwards tools from config to SDK options", %{config: config} do
+        config = Map.put(config, :tools, [])
+
+        expect(ClaudeAgentSDK, :query, fn _prompt, opts ->
+          assert opts.tools == []
+          sdk_messages("s1")
+        end)
+
+        messages = [Message.new(:user, "hello")]
+        {:ok, _response} = Backend.call(config, messages, [])
+      end
+
+      test "tools defaults to nil when not in config", %{config: config} do
+        expect(ClaudeAgentSDK, :query, fn _prompt, opts ->
+          assert opts.tools == nil
+          sdk_messages("s1")
+        end)
+
+        messages = [Message.new(:user, "hello")]
+        {:ok, _response} = Backend.call(config, messages, [])
+      end
+    end
+
     describe "call/3 session resume" do
       test "starts new session when no session_id in messages", %{config: config} do
         expect(ClaudeAgentSDK, :query, fn "hello", _opts ->


### PR DESCRIPTION
## Summary

- Forward `config[:tools]` to `ClaudeAgentSDK.Options` in `build_sdk_options/3`
- Enables tool-free chatbots via `tools: []` (the SDK emits `--tools ""` to the CLI)
- Add tests verifying tools forwarding and nil default

## Test plan

- [x] `mix test test/puck/backends/claude_agent_sdk_test.exs` — 19 tests pass
- [x] `mix compile --warnings-as-errors` — clean