### PR TITLE
Decode Lua table arguments to Elixir maps in sandbox callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Replaced deprecated `strict: true` with `unrecognized_keys: :error` for Zoi 0.17 compatibility
+- Lua sandbox callbacks now receive maps when Lua passes table arguments (previously returned opaque internal references)
 
 ### Changed
 

--- a/lib/puck/sandbox/eval/lua.ex
+++ b/lib/puck/sandbox/eval/lua.ex
@@ -191,11 +191,18 @@ defmodule Puck.Sandbox.Eval.Lua do
 
     defp wrap_callback(func) do
       fn args, lua_state ->
-        result = apply(func, args) |> stringify_keys()
+        decoded_args = Enum.map(args, &decode_arg(&1, lua_state))
+        result = apply(func, decoded_args) |> stringify_keys()
         {encoded, lua_state} = Lua.encode!(lua_state, result)
         {[encoded], lua_state}
       end
     end
+
+    defp decode_arg({:tref, _} = ref, lua_state) do
+      Lua.decode!(lua_state, ref) |> normalize()
+    end
+
+    defp decode_arg(arg, _lua_state), do: arg
 
     defp stringify_keys(map) when is_map(map) and not is_struct(map) do
       Map.new(map, fn

--- a/test/puck/sandbox/eval/lua_test.exs
+++ b/test/puck/sandbox/eval/lua_test.exs
@@ -86,6 +86,52 @@ defmodule Puck.Sandbox.Eval.LuaTest do
       assert {:ok, "bar"} = Lua.eval("return get_items()[2].name", callbacks: callbacks)
     end
 
+    test "callback receives decoded table argument as map" do
+      callbacks = %{
+        "process" => fn opts -> opts end
+      }
+
+      {:ok, result} =
+        Lua.eval(
+          ~s[return process({mode = "fast", retries = 3})],
+          callbacks: callbacks
+        )
+
+      assert is_map(result)
+      assert result == %{"mode" => "fast", "retries" => 3}
+    end
+
+    test "callback receives decoded nested table argument" do
+      callbacks = %{
+        "process" => fn opts -> opts end
+      }
+
+      {:ok, result} =
+        Lua.eval(
+          ~s[return process({user = {name = "Alice"}, active = true})],
+          callbacks: callbacks
+        )
+
+      assert is_map(result)
+      assert result["user"] == %{"name" => "Alice"}
+      assert result["active"] == true
+    end
+
+    test "callback receives mixed args with table decoded" do
+      callbacks = %{
+        "create" => fn name, opts -> %{"name" => name, "opts" => opts} end
+      }
+
+      {:ok, result} =
+        Lua.eval(
+          ~s[return create("test", {priority = "high"})],
+          callbacks: callbacks
+        )
+
+      assert result["name"] == "test"
+      assert result["opts"] == %{"priority" => "high"}
+    end
+
     test "timeout on infinite loop" do
       assert {:error, :timeout} =
                Lua.eval(


### PR DESCRIPTION
## Summary

- Lua sandbox `wrap_callback/1` now decodes `{:tref, N}` table references to Elixir maps before passing arguments to host callbacks
- Callbacks that receive Lua table arguments now get proper Elixir maps with string keys instead of raw Luerl internal references

Closes #12

## Test plan

- [x] Added 3 tests: flat table, nested table, and mixed args with table
- [x] Verified tests fail before fix (raw `{:tref, N}` causes `Lua.encode!` crash)
- [x] Full test suite passes (431 tests, 0 failures)
- [x] Pre-release review completed with no actionable findings