### PR TITLE
Fix dynamic class TypeBuilder to emit enum values with descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - BAML backend now strips `__baml_class__` and `__baml_enum__` metadata from NIF results before Zoi parsing, fixing struct parsing failures when `output_schema` is used
-- BAML `dynamic_classes` TypeBuilder now emits a proper `TB.Enum` with per-value descriptions for type discriminators, fixing plugin actions being collapsed to `{ type: string }` in the rendered prompt
+- BAML `dynamic_classes` TypeBuilder now emits a dedicated enum for type discriminators with descriptions, fixing union variants being collapsed to `{ type: string }` in rendered prompts
 
 ## [0.2.15] - 2026-02-14
 
@@ -204,7 +204,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 The first release!
 
-[Unreleased]: https://github.com/bradleygolden/puck/compare/v0.2.13...HEAD
+[Unreleased]: https://github.com/bradleygolden/puck/compare/v0.2.15...HEAD
+[0.2.15]: https://github.com/bradleygolden/puck/compare/v0.2.14...v0.2.15
+[0.2.14]: https://github.com/bradleygolden/puck/compare/v0.2.13...v0.2.14
 [0.2.13]: https://github.com/bradleygolden/puck/compare/v0.2.12...v0.2.13
 [0.2.12]: https://github.com/bradleygolden/puck/compare/v0.2.11...v0.2.12
 [0.2.11]: https://github.com/bradleygolden/puck/compare/v0.2.10...v0.2.11

--- a/lib/puck/backends/baml.ex
+++ b/lib/puck/backends/baml.ex
@@ -31,7 +31,6 @@ if Code.ensure_loaded?(BamlElixir.Client) do
 
     @behaviour Puck.Backend
 
-    alias BamlElixir.TypeBuilder, as: TB
     alias Puck.Backends.Baml.TypeBuilder
     alias Puck.{Message, Response}
 
@@ -180,67 +179,11 @@ if Code.ensure_loaded?(BamlElixir.Client) do
     end
 
     defp build_type_builder(
-           %Zoi.Types.Union{schemas: schemas},
+           %Zoi.Types.Union{} = union_schema,
            dynamic_classes,
            schema_descriptions
          ) do
-      dynamic_modules =
-        dynamic_classes
-        |> Map.values()
-        |> List.flatten()
-        |> MapSet.new()
-
-      dynamic_schemas =
-        Enum.filter(schemas, fn
-          %Zoi.Types.Struct{module: mod} -> mod in dynamic_modules
-          _ -> false
-        end)
-
-      type_values =
-        Enum.flat_map(dynamic_schemas, fn %Zoi.Types.Struct{fields: fields} ->
-          case Keyword.get(fields, :type) do
-            %Zoi.Types.Enum{values: [{value, _} | _]} -> [value]
-            %Zoi.Types.Enum{values: [value | _]} when is_binary(value) -> [value]
-            _ -> []
-          end
-        end)
-
-      dynamic_fields =
-        dynamic_schemas
-        |> Enum.flat_map(fn %Zoi.Types.Struct{fields: fields} ->
-          fields
-          |> Keyword.keys()
-          |> Enum.reject(&(&1 == :type))
-          |> Enum.map(&to_string/1)
-        end)
-        |> Enum.uniq()
-
-      Enum.flat_map(dynamic_classes, fn {class_name, _modules} ->
-        type_enum_name = class_name <> "Type"
-
-        type_enum = %TB.Enum{
-          name: type_enum_name,
-          values:
-            Enum.map(type_values, fn value ->
-              %TB.EnumValue{
-                value: value,
-                description: Map.get(schema_descriptions, value)
-              }
-            end)
-        }
-
-        other_fields =
-          Enum.map(dynamic_fields, fn name ->
-            %TB.Field{name: name, type: %TB.Union{types: [:string, :null]}}
-          end)
-
-        class = %TB.Class{
-          name: class_name,
-          fields: other_fields
-        }
-
-        [type_enum, class]
-      end)
+      TypeBuilder.from_dynamic_union(union_schema, dynamic_classes, schema_descriptions)
     end
 
     defp build_type_builder(output_schema, _dynamic_classes, schema_descriptions) do

--- a/lib/puck/backends/baml/type_builder.ex
+++ b/lib/puck/backends/baml/type_builder.ex
@@ -27,6 +27,80 @@ if Code.ensure_loaded?(BamlElixir.Client) do
     alias BamlElixir.TypeBuilder, as: TB
 
     @doc """
+    Builds TypeBuilder structs for a union schema with dynamic classes.
+
+    When a union schema has runtime-declared dynamic classes, this function
+    emits a `TB.Enum` for the type discriminator (with per-value descriptions)
+    and a `TB.Class` for the shared dynamic fields. Non-type fields are collected
+    from all dynamic schemas and emitted as `string | null` unions.
+
+    Returns a flat list of `TB.Enum` and `TB.Class` structs.
+    """
+    def from_dynamic_union(
+          %Zoi.Types.Union{schemas: schemas},
+          dynamic_classes,
+          schema_descriptions \\ %{}
+        ) do
+      dynamic_modules =
+        dynamic_classes
+        |> Map.values()
+        |> List.flatten()
+        |> MapSet.new()
+
+      dynamic_schemas =
+        Enum.filter(schemas, fn
+          %Zoi.Types.Struct{module: mod} -> mod in dynamic_modules
+          _ -> false
+        end)
+
+      type_values =
+        Enum.flat_map(dynamic_schemas, fn %Zoi.Types.Struct{fields: fields} ->
+          case Keyword.get(fields, :type) do
+            %Zoi.Types.Enum{values: [{value, _} | _]} -> [value]
+            %Zoi.Types.Enum{values: [value | _]} when is_binary(value) -> [value]
+            _ -> []
+          end
+        end)
+
+      dynamic_fields =
+        dynamic_schemas
+        |> Enum.flat_map(fn %Zoi.Types.Struct{fields: fields} ->
+          fields
+          |> Keyword.keys()
+          |> Enum.reject(&(&1 == :type))
+          |> Enum.map(&to_string/1)
+        end)
+        |> Enum.uniq()
+
+      Enum.flat_map(dynamic_classes, fn {class_name, _modules} ->
+        type_enum_name = class_name <> "Type"
+
+        type_enum = %TB.Enum{
+          name: type_enum_name,
+          values:
+            Enum.map(type_values, fn value ->
+              %TB.EnumValue{
+                value: value,
+                description: Map.get(schema_descriptions, value)
+              }
+            end)
+        }
+
+        other_fields =
+          Enum.map(dynamic_fields, fn name ->
+            %TB.Field{name: name, type: %TB.Union{types: [:string, :null]}}
+          end)
+
+        class = %TB.Class{
+          name: class_name,
+          fields: other_fields
+        }
+
+        [type_enum, class]
+      end)
+    end
+
+    @doc """
     Converts a Zoi schema to a list of `BamlElixir.TypeBuilder` structs.
 
     Returns a list of named types (classes, enums) that BAML's Rust runtime

--- a/test/puck/backends/baml/type_builder_test.exs
+++ b/test/puck/backends/baml/type_builder_test.exs
@@ -393,5 +393,134 @@ if Code.ensure_loaded?(BamlElixir.Client) do
         assert Enum.any?(types, &(&1.name == "DynamicOutputHomeAddress"))
       end
     end
+
+    describe "from_dynamic_union/3" do
+      defmodule ActionA do
+        defstruct type: "action_a", name: nil
+      end
+
+      defmodule ActionB do
+        defstruct type: "action_b", count: nil
+      end
+
+      defp union_schema do
+        Zoi.union([
+          Zoi.struct(ActionA, %{
+            type: Zoi.enum(["action_a"]),
+            name: Zoi.string()
+          }),
+          Zoi.struct(ActionB, %{
+            type: Zoi.enum(["action_b"]),
+            count: Zoi.integer()
+          })
+        ])
+      end
+
+      defp dynamic_classes do
+        %{"PluginAction" => [ActionA, ActionB]}
+      end
+
+      test "emits a TB.Enum for the type discriminator" do
+        result = TypeBuilder.from_dynamic_union(union_schema(), dynamic_classes())
+
+        type_enum = Enum.find(result, &match?(%TB.Enum{}, &1))
+        assert %TB.Enum{name: "PluginActionType"} = type_enum
+
+        values = Enum.map(type_enum.values, & &1.value)
+        assert "action_a" in values
+        assert "action_b" in values
+      end
+
+      test "emits a TB.Class with non-type fields as string | null" do
+        result = TypeBuilder.from_dynamic_union(union_schema(), dynamic_classes())
+
+        class = Enum.find(result, &match?(%TB.Class{}, &1))
+        assert %TB.Class{name: "PluginAction", fields: fields} = class
+
+        field_names = Enum.map(fields, & &1.name)
+        assert "name" in field_names
+        assert "count" in field_names
+        refute "type" in field_names
+
+        for field <- fields do
+          assert %TB.Union{types: [:string, :null]} = field.type
+        end
+      end
+
+      test "attaches descriptions to enum values from schema_descriptions" do
+        descriptions = %{
+          "action_a" => "Performs action A",
+          "action_b" => "Performs action B"
+        }
+
+        result =
+          TypeBuilder.from_dynamic_union(union_schema(), dynamic_classes(), descriptions)
+
+        type_enum = Enum.find(result, &match?(%TB.Enum{}, &1))
+
+        a_value = Enum.find(type_enum.values, &(&1.value == "action_a"))
+        b_value = Enum.find(type_enum.values, &(&1.value == "action_b"))
+
+        assert a_value.description == "Performs action A"
+        assert b_value.description == "Performs action B"
+      end
+
+      test "enum values have nil descriptions when schema_descriptions is empty" do
+        result = TypeBuilder.from_dynamic_union(union_schema(), dynamic_classes())
+
+        type_enum = Enum.find(result, &match?(%TB.Enum{}, &1))
+
+        for ev <- type_enum.values do
+          assert is_nil(ev.description)
+        end
+      end
+
+      test "returns both enum and class per dynamic class entry" do
+        result = TypeBuilder.from_dynamic_union(union_schema(), dynamic_classes())
+
+        assert length(result) == 2
+        assert Enum.count(result, &match?(%TB.Enum{}, &1)) == 1
+        assert Enum.count(result, &match?(%TB.Class{}, &1)) == 1
+      end
+
+      test "handles multiple dynamic class groups" do
+        classes = %{
+          "PluginAction" => [ActionA, ActionB],
+          "OtherAction" => [ActionA]
+        }
+
+        result = TypeBuilder.from_dynamic_union(union_schema(), classes)
+
+        enum_names =
+          result |> Enum.filter(&match?(%TB.Enum{}, &1)) |> Enum.map(& &1.name)
+
+        class_names =
+          result |> Enum.filter(&match?(%TB.Class{}, &1)) |> Enum.map(& &1.name)
+
+        assert "PluginActionType" in enum_names
+        assert "OtherActionType" in enum_names
+        assert "PluginAction" in class_names
+        assert "OtherAction" in class_names
+      end
+
+      test "skips schemas not in dynamic_classes" do
+        schema =
+          Zoi.union([
+            Zoi.struct(ActionA, %{type: Zoi.enum(["action_a"]), name: Zoi.string()}),
+            Zoi.struct(ActionB, %{type: Zoi.enum(["action_b"]), count: Zoi.integer()})
+          ])
+
+        only_a = %{"PluginAction" => [ActionA]}
+        result = TypeBuilder.from_dynamic_union(schema, only_a)
+
+        type_enum = Enum.find(result, &match?(%TB.Enum{}, &1))
+        values = Enum.map(type_enum.values, & &1.value)
+        assert values == ["action_a"]
+
+        class = Enum.find(result, &match?(%TB.Class{}, &1))
+        field_names = Enum.map(class.fields, & &1.name)
+        assert field_names == ["name"]
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

- When `dynamic_classes` are used with a discriminated union schema (e.g. plugin actions), the previous `build_type_builder/3` collapsed all dynamic types into `{ type: string }` in the rendered BAML prompt, making plugin actions invisible to the LLM
- Now extracts type discriminator values from each plugin schema and emits a proper `TB.Enum` (with per-value descriptions) alongside the `TB.Class`
- The `type` field and enum type are expected to be pre-defined in the BAML template as `@@dynamic`; this only adds values and extra fields at runtime

## Context

The BAML backend's `ctx.output_format` was rendering all plugin actions as a single `{ type: string }` variant, so the model had no way to know which plugin actions existed. After this fix, the output format shows each plugin type as an enum value with its description, allowing the model to correctly choose plugin actions over shell commands.

## Test plan

- [ ] Verify that `build_type_builder/3` with `dynamic_classes` produces `TB.Enum` with correct values and descriptions
- [ ] Verify that the rendered `ctx.output_format` in BAML shows all plugin types (not collapsed to `string`)
- [ ] Test end-to-end with puck_coder plugins to confirm model selects plugin actions