### PR TITLE
Fix nil field descriptions in dynamic TypeBuilder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- BAML `dynamic_classes` TypeBuilder no longer renders `// nil` comments on dynamic fields in prompts
+
 ## [0.2.16] - 2026-02-14
 
 ### Fixed

--- a/lib/puck/backends/baml/type_builder.ex
+++ b/lib/puck/backends/baml/type_builder.ex
@@ -88,7 +88,7 @@ if Code.ensure_loaded?(BamlElixir.Client) do
 
         other_fields =
           Enum.map(dynamic_fields, fn name ->
-            %TB.Field{name: name, type: %TB.Union{types: [:string, :null]}}
+            %TB.Field{name: name, type: %TB.Union{types: [:string, :null]}, description: ""}
           end)
 
         class = %TB.Class{

--- a/test/puck/backends/baml/type_builder_test.exs
+++ b/test/puck/backends/baml/type_builder_test.exs
@@ -444,6 +444,7 @@ if Code.ensure_loaded?(BamlElixir.Client) do
 
         for field <- fields do
           assert %TB.Union{types: [:string, :null]} = field.type
+          assert field.description == ""
         end
       end
 

--- a/test/puck/backends/baml_integration_test.exs
+++ b/test/puck/backends/baml_integration_test.exs
@@ -142,6 +142,56 @@ if Code.ensure_loaded?(BamlElixir.Client) do
       end
     end
 
+    describe "dynamic_classes prompt rendering" do
+      defmodule ActionSearch do
+        @moduledoc false
+        defstruct type: "search", query: nil
+      end
+
+      defmodule ActionDone do
+        @moduledoc false
+        defstruct type: "done", message: nil
+      end
+
+      @tag timeout: 60_000
+      test "dynamic fields do not render // nil comments in prompt" do
+        alias Puck.Backends.Baml.TypeBuilder
+
+        schema =
+          Zoi.union([
+            Zoi.struct(ActionSearch, %{type: Zoi.enum(["search"]), query: Zoi.string()}),
+            Zoi.struct(ActionDone, %{type: Zoi.enum(["done"]), message: Zoi.string()})
+          ])
+
+        dynamic_classes = %{"PluginAction" => [ActionSearch, ActionDone]}
+        descriptions = %{"search" => "Search for items", "done" => "Task complete"}
+
+        tb = TypeBuilder.from_dynamic_union(schema, dynamic_classes, descriptions)
+
+        collector = BamlElixir.Collector.new("prompt-check")
+
+        {:ok, _result} =
+          BamlElixir.Client.call(
+            "ChoosePluginAction",
+            %{text: "Search for cats"},
+            %{
+              path: "test/support/baml_src",
+              parse: false,
+              tb: tb,
+              collectors: [collector]
+            }
+          )
+
+        log = BamlElixir.Collector.last_function_log(collector)
+        body = get_in(log, ["calls", Access.at(0), "request", "body"])
+        prompt = Jason.decode!(body)
+        system_content = Enum.find(prompt["messages"], &(&1["role"] == "system"))["content"]
+
+        refute system_content =~ "// nil",
+               "Prompt should not contain '// nil' comments but got:\n#{system_content}"
+      end
+    end
+
     defp check_ollama_available do
       url = "http://localhost:11434/api/tags"
 

--- a/test/support/baml_src/dynamic_action.baml
+++ b/test/support/baml_src/dynamic_action.baml
@@ -1,0 +1,14 @@
+class PluginAction {
+  @@dynamic
+}
+
+function ChoosePluginAction(text: string) -> PluginAction {
+  client Ollama
+  prompt #"
+    Given the user query, choose the appropriate action.
+    {{ ctx.output_format }}
+
+    {{ _.role('user') }}
+    {{ text }}
+  "#
+}


### PR DESCRIPTION
## Summary
- Set `description: ""` on dynamic `TB.Field` structs in `from_dynamic_union/3` to prevent the BAML Rust runtime from rendering `// nil` comments in `ctx.output_format`
- When plugins are registered, the `path` field (and other dynamic fields) no longer show `// nil` in LLM prompts

## Test plan
- [ ] `mix test test/puck/backends/baml/type_builder_test.exs` passes (updated assertion verifies `description == ""`)
- [ ] Inspect BAML prompt output with plugins — no `// nil` comments on dynamic fields